### PR TITLE
Add separate final stages for download and scrape build targets

### DIFF
--- a/.github/workflows/docker-build-push.yml
+++ b/.github/workflows/docker-build-push.yml
@@ -64,7 +64,7 @@ jobs:
           labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
-          target: download
+          target: final-download
           build-args: |
             INFRACOST_API_KEY=${{ secrets.INFRACOST_API_KEY }}
             AWS_ACCESS_KEY_ID=${{ secrets.AWS_ACCESS_KEY_ID }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -70,8 +70,8 @@ RUN su-exec postgres pg_ctl start -D /var/lib/postgresql/data && \
     rm -f /usr/src/app/data/products/products.csv.gz && \
     su-exec postgres pg_ctl stop -D /var/lib/postgresql/data
 
-# Final stage - copy from either download or scrape (default: scrape)
-FROM scrape AS final
+# Final stage for download path
+FROM download AS final-download
 
 # Copy entrypoint
 COPY docker-entrypoint.sh /docker-entrypoint.sh
@@ -80,3 +80,17 @@ RUN chmod +x /docker-entrypoint.sh
 ENV NODE_ENV=production
 EXPOSE 4000
 ENTRYPOINT ["/docker-entrypoint.sh"]
+
+# Final stage for scrape path
+FROM scrape AS final-scrape
+
+# Copy entrypoint
+COPY docker-entrypoint.sh /docker-entrypoint.sh
+RUN chmod +x /docker-entrypoint.sh
+
+ENV NODE_ENV=production
+EXPOSE 4000
+ENTRYPOINT ["/docker-entrypoint.sh"]
+
+# Default final stage (uses scrape path)
+FROM final-scrape AS final


### PR DESCRIPTION
- Create final-download stage that includes entrypoint from download stage
- Create final-scrape stage that includes entrypoint from scrape stage
- Update GitHub workflow to target final-download instead of download
- Fixes issue where containers built with --target download had no entrypoint

🤖 Generated with [Claude Code](https://claude.ai/code)