### PR TITLE
Fix Docker build to properly isolate secrets from final image

### DIFF
--- a/.github/workflows/docker-build-push.yml
+++ b/.github/workflows/docker-build-push.yml
@@ -67,12 +67,6 @@ jobs:
           target: final-download
           build-args: |
             INFRACOST_API_KEY=${{ secrets.INFRACOST_API_KEY }}
-            AWS_ACCESS_KEY_ID=${{ secrets.AWS_ACCESS_KEY_ID }}
-            AWS_SECRET_ACCESS_KEY=${{ secrets.AWS_SECRET_ACCESS_KEY }}
-            AZURE_CLIENT_ID=${{ secrets.AZURE_CLIENT_ID }}
-            AZURE_CLIENT_SECRET=${{ secrets.AZURE_CLIENT_SECRET }}
-            AZURE_TENANT_ID=${{ secrets.AZURE_TENANT_ID }}
-            GCP_API_KEY=${{ secrets.GCP_API_KEY }}
           provenance: false
 
   create-manifest:


### PR DESCRIPTION
- Remove sensitive environment variables from base stage
- Move INFRACOST_API_KEY to download build stage only
- Move cloud provider credentials to scrape build stage only
- Update final stages to inherit from build stages and clear secrets
- Update GitHub workflow to only pass INFRACOST_API_KEY for download target

This ensures API keys and credentials are available during build but not present in the final Docker image layers.

🤖 Generated with [Claude Code](https://claude.ai/code)